### PR TITLE
fixed http protocol error (expected 'http:', not 'http')

### DIFF
--- a/src/gizoogle.js
+++ b/src/gizoogle.js
@@ -8,7 +8,7 @@ var HOSTNAME = 'gizoogle.net';
 
 function createRequest(path, payload, callback) {
     return http.request({
-        protocol: 'http',
+        protocol: 'http:',
         hostname: HOSTNAME,
         port: 80,
         path: path,


### PR DESCRIPTION
I was running into some errors running this locally, and I fixed them by changing the protocol parameter from 'http' to 'http:'. Below is the stack trace I was getting before the fix:

```
Error: Protocol "http" not supported. Expected "http:".
    at new ClientRequest (_http_client.js:75:11)
    at Object.exports.request (http.js:49:10)
    at createRequest (/Users/bodeckerdellamaria/Documents/Comp Sci/gizoogle-slack-integration/node_modules/gizoogle/src/gizoogle.js:10:17)
    at Object.module.exports.string (/Users/bodeckerdellamaria/Documents/Comp Sci/gizoogle-slack-integration/node_modules/gizoogle/src/gizoogle.js:38:19)
    at /Users/bodeckerdellamaria/Documents/Comp Sci/gizoogle-slack-integration/server.js:7:4
    at Layer.handle [as handle_request] (/Users/bodeckerdellamaria/Documents/Comp Sci/gizoogle-slack-integration/node_modules/express/lib/router/layer.js:95:5)
    at next (/Users/bodeckerdellamaria/Documents/Comp Sci/gizoogle-slack-integration/node_modules/express/lib/router/route.js:131:13)
    at Route.dispatch (/Users/bodeckerdellamaria/Documents/Comp Sci/gizoogle-slack-integration/node_modules/express/lib/router/route.js:112:3)
    at Layer.handle [as handle_request] (/Users/bodeckerdellamaria/Documents/Comp Sci/gizoogle-slack-integration/node_modules/express/lib/router/layer.js:95:5)
    at /Users/bodeckerdellamaria/Documents/Comp Sci/gizoogle-slack-integration/node_modules/express/lib/router/index.js:277:22
```
